### PR TITLE
Fix makefile fs-externs path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,19 +73,21 @@ EMFLAGS_PRE_JS_FILES = \
 
 EXPORTED_METHODS_JSON_FILES = src/exported_functions.json src/exported_runtime_methods.json
 
+FS_EXTERN_PATH = "$(realpath -s ./src/fs-externs.js)"
+
 all: optimized debug worker
 
 .PHONY: debug
 debug: dist/sql-asm-debug.js dist/sql-wasm-debug.js
 
 dist/sql-asm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
-	EMCC_CLOSURE_ARGS="--externs src/fs-externs.js" $(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	EMCC_CLOSURE_ARGS="--externs ${FS_EXTERN_PATH}" $(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
 
 dist/sql-wasm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
-	EMCC_CLOSURE_ARGS="--externs src/fs-externs.js" $(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	EMCC_CLOSURE_ARGS="--externs ${FS_EXTERN_PATH}" $(EMCC) $(EMFLAGS) $(EMFLAGS_DEBUG) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
@@ -94,19 +96,19 @@ dist/sql-wasm-debug.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FI
 optimized: dist/sql-asm.js dist/sql-wasm.js dist/sql-asm-memory-growth.js
 
 dist/sql-asm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
-	EMCC_CLOSURE_ARGS="--externs src/fs-externs.js" $(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	EMCC_CLOSURE_ARGS="--externs ${FS_EXTERN_PATH}" $(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
 
 dist/sql-wasm.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
-	EMCC_CLOSURE_ARGS="--externs src/fs-externs.js" $(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	EMCC_CLOSURE_ARGS="--externs ${FS_EXTERN_PATH}" $(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_WASM) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js
 
 dist/sql-asm-memory-growth.js: $(BITCODE_FILES) $(OUTPUT_WRAPPER_FILES) $(SOURCE_API_FILES) $(EXPORTED_METHODS_JSON_FILES)
-	EMCC_CLOSURE_ARGS="--externs src/fs-externs.js" $(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM_MEMORY_GROWTH) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
+	EMCC_CLOSURE_ARGS="--externs ${FS_EXTERN_PATH}" $(EMCC) $(EMFLAGS) $(EMFLAGS_OPTIMIZED) $(EMFLAGS_ASM_MEMORY_GROWTH) $(BITCODE_FILES) $(EMFLAGS_PRE_JS_FILES) -o $@
 	mv $@ out/tmp-raw.js
 	cat src/shell-pre.js out/tmp-raw.js src/shell-post.js > $@
 	rm out/tmp-raw.js


### PR DESCRIPTION
I was not able to compile sql.js, but after this fix, it works well. The makefile was not able to find fs-externs.js. I was getting this error:

```
building:ERROR: Closure compiler run failed:

building:ERROR: ERROR - [JSC_READ_ERROR] Cannot read file src/fs-externs.js: src/fs-externs.js

1 error(s), 0 warning(s)

emcc: error: closure compiler failed (rc: 1): /Users/quolpr/.asdf/shims/node --max_old_space_size=8192 /opt/homebrew/Cellar/emscripten/2.0.29/libexec/node_modules/.bin/google-closure-compiler --compilation_level ADVANCED_OPTIMIZATIONS --language_in ECMASCRIPT_2020 --language_out NO_TRANSPILE --emit_use_strict=false --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/src/closure-externs/closure-externs.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/src/closure-externs/node-externs.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/net.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/events.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/repl.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/util.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/dgram.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/vm.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/stream.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/child_process.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/assert.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/core.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/os.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/readline.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/punycode.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/https.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/domain.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/dns.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/tty.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/querystring.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/path.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/string_decoder.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/cluster.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/zlib.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/url.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/tls.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/process.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/http.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/buffer.js --externs /opt/homebrew/Cellar/emscripten/2.0.29/libexec/third_party/closure-compiler/node-externs/fs.js --js_output_file tmpzaf3_5kx.cc.js --js /var/folders/0c/yctxdr7d6b5fn9pvb8r6rs640000gn/T/emscripten_temp_qaujegkd/sql-asm.js.pp.js.jso.js.jso.js.jso.js.jso.js --externs src/fs-externs.js the error message may be clearer with -g1 and EMCC_DEBUG=2 set
make: *** [dist/sql-asm.js] Error 1
```